### PR TITLE
Improve SQL extraction and UI styling

### DIFF
--- a/backend/extract_graph.py
+++ b/backend/extract_graph.py
@@ -24,9 +24,24 @@ def extract_from_internal_components(xml_path):
         if not node_id:
             continue
 
+        # Extract optional SQL query or procedure
+        params = {c.attrib.get("name"): c.attrib.get("value") for c in comp.findall("parameters/column")}
+        query = params.get("Query")
+        procedure = params.get("Procedure")
+        if query and query.startswith('"') and query.endswith('"'):
+            query = query[1:-1]
+        if procedure and procedure.startswith('"') and procedure.endswith('"'):
+            procedure = procedure[1:-1]
+
+        node_data = {"label": comp_type}
+        if query:
+            node_data["sql"] = query
+        if procedure:
+            node_data["procedure"] = procedure
+
         nodes.append({
             "id": node_id,
-            "data": {"label": comp_type},
+            "data": node_data,
             "position": {"x": x, "y": 100 + idx * y_spacing}
         })
 

--- a/index.html
+++ b/index.html
@@ -4,9 +4,12 @@
     <meta charset="UTF-8" />
     <title>Talend Job Converter</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="https://unpkg.com/react-flow-renderer@10.3.17/dist/style.css" />
     <style>
-      body { margin: 0; font-family: Roboto, Arial, sans-serif; }
+      body { margin: 0; font-family: 'Inter', Roboto, Arial, sans-serif; background-color: #f5f7fa; }
       #root { height: 100vh; }
     </style>
     <script type="module" src="/src/main.jsx"></script>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import {
   Toolbar,
   Typography,
   Box,
+  CssBaseline,
 } from '@mui/material';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { ReactFlowProvider, ReactFlow } from 'reactflow';
@@ -22,11 +23,14 @@ function App() {
   const theme = createTheme({
     palette: {
       primary: {
-        main: '#1976d2',
+        main: '#0288d1',
       },
       background: {
-        default: '#fafafa',
+        default: '#f5f7fa',
       },
+    },
+    typography: {
+      fontFamily: 'Inter, Roboto, Arial, sans-serif',
     },
   });
 
@@ -162,6 +166,7 @@ function App() {
 
   return (
     <ThemeProvider theme={theme}>
+      <CssBaseline />
       <Box sx={{ height: '100%' }}>
         <AppBar position="static">
           <Toolbar>
@@ -207,9 +212,17 @@ function App() {
 
           <Drawer anchor="right" open={Boolean(selectedNode)} onClose={() => setSelectedNode(null)}>
             {selectedNode && (
-              <Box sx={{ width: 250, p: 2 }}>
+              <Box sx={{ width: 300, p: 2 }}>
                 <Typography variant="h6" gutterBottom>{selectedNode.data.label}</Typography>
-                <Typography variant="body2">ID: {selectedNode.id}</Typography>
+                <Typography variant="body2" gutterBottom>ID: {selectedNode.id}</Typography>
+                {selectedNode.data.sql && (
+                  <Box component="pre" sx={{ whiteSpace: 'pre-wrap', fontSize: '0.75rem', mt: 1 }}>
+                    {selectedNode.data.sql}
+                  </Box>
+                )}
+                {selectedNode.data.procedure && (
+                  <Typography variant="body2" sx={{ mt: 1 }}>Procedure: {selectedNode.data.procedure}</Typography>
+                )}
               </Box>
             )}
           </Drawer>


### PR DESCRIPTION
## Summary
- parse SQL and procedure names from Talend `.item` files
- display query/procedure in the node info drawer
- apply a SaaS-style theme and baseline styling

## Testing
- `npm test`
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6850a6d87d48832fa86aa9db345fbc0a