### PR TITLE
Add DAG comparison with Groq

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Then open the printed local URL in your browser. If uploading directories is blo
 - Parse each file client-side to extract component names, SQL snippets and basic dependencies.
 - Visualise the selected job using React Flow. Nodes representing `tRunJob` or joblets can be expanded.
 - Click nodes to view details and any detected SQL.
-- Generate a Python file containing a skeleton Airflow DAG. Database connections reference credentials from AWS Secrets Manager.
+- Generate a Python file containing a skeleton Airflow DAG and automatically compare it with the original job using Groq's LLM. Database connections reference credentials from AWS Secrets Manager.
 - Download a DBT-style DAG and automatically compare it with the original job using Groq's LLM.
 
 This is a basic demo and may need adjustments for different Talend documentation formats.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -127,7 +127,7 @@ function App() {
     }
   };
 
-  const generateDag = () => {
+  const generateDag = async () => {
     if (!jobName || nodes.length === 0) return;
 
     const dagLines = [
@@ -205,13 +205,34 @@ function App() {
     });
 
     const lines = dagLines.concat(operatorLines, edgeLines);
-    const blob = new Blob([lines.join("\n")], { type: "text/x-python" });
+    const dagContent = lines.join("\n");
+    const blob = new Blob([dagContent], { type: "text/x-python" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
     a.download = `${jobName.replace(/\s+/g, "_")}_dag.py`;
     a.click();
     URL.revokeObjectURL(url);
+
+    try {
+      const res = await fetch('http://localhost:5000/compare_dag', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          job_steps: nodes.map(n => n.id),
+          dag_text: dagContent,
+        }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        alert(data.result);
+      } else {
+        const errText = await res.text();
+        console.error('Comparison failed:', errText);
+      }
+    } catch (err) {
+      console.error('Comparison error:', err);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- compare Airflow DAGs with the original Talend job after download
- document that DAG downloads also run Groq comparison

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850b514f0f0832fa92bdd6290ba789f